### PR TITLE
Prohibits shaded imports; upgrade to checkstyle 6.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     </licenses>
 
     <properties>
-        <version.checkstyle>6.8.1</version.checkstyle>
+        <version.checkstyle>6.11</version.checkstyle>
         <version.junit>4.11</version.junit>
         <maven.checkstyle.checks.opower_libs_checks>false</maven.checkstyle.checks.opower_libs_checks>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <groupId>com.opower</groupId>
     <artifactId>opower-checks</artifactId>
     <packaging>jar</packaging>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <name>Opower Checkstyle Checks</name>
     <url>http://www.opower.com/</url>
 

--- a/release_notes.txt
+++ b/release_notes.txt
@@ -1,2 +1,5 @@
+1.1.0
+ * Prohibit import of shaded packages (if the full package name includes ".shaded.")
+
 1.0.0
  * Initial commit for open sourcing opower-checks

--- a/release_notes.txt
+++ b/release_notes.txt
@@ -1,5 +1,6 @@
 1.1.0
  * Prohibit import of shaded packages (if the full package name includes ".shaded.")
+ * Upgrade to Checkstyle 6.11
 
 1.0.0
  * Initial commit for open sourcing opower-checks

--- a/src/main/java/com/opower/checkstyle/checks/javadoc/JavadocTagCheck.java
+++ b/src/main/java/com/opower/checkstyle/checks/javadoc/JavadocTagCheck.java
@@ -4,17 +4,17 @@ import java.util.List;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
-import com.puppycrawl.tools.checkstyle.ScopeUtils;
 import com.puppycrawl.tools.checkstyle.api.Check;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FileContents;
-import com.puppycrawl.tools.checkstyle.api.JavadocTagInfo;
 import com.puppycrawl.tools.checkstyle.api.Scope;
 import com.puppycrawl.tools.checkstyle.api.TextBlock;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTag;
+import com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTagInfo;
 import com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTags;
-import com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocUtils;
+import com.puppycrawl.tools.checkstyle.utils.JavadocUtils;
+import com.puppycrawl.tools.checkstyle.utils.ScopeUtils;
 
 /**
  * Checks the tags in Javadoc.
@@ -124,14 +124,11 @@ public class JavadocTagCheck extends Check {
         }
 
         if (aAST.getType() == TokenTypes.PACKAGE_DEF) {
-            if (getFileContents().getFileName().endsWith("package-info.java")) {
-                return true;
-            }
-            return false;
+            return getFileContents().getFileName().endsWith("package-info.java");
         }
         final DetailAST mods = aAST.findFirstToken(TokenTypes.MODIFIERS);
         final Scope declaredScope = ScopeUtils.getScopeFromMods(mods);
-        final Scope scope = ScopeUtils.inInterfaceOrAnnotationBlock(aAST) ? Scope.PUBLIC : declaredScope;
+        final Scope scope = ScopeUtils.isInInterfaceOrAnnotationBlock(aAST) ? Scope.PUBLIC : declaredScope;
         final Scope surroundingScope = ScopeUtils.getSurroundingScope(aAST);
         return scope.isIn(this.mScope) && ((surroundingScope == null) || surroundingScope.isIn(this.mScope));
     }
@@ -166,7 +163,7 @@ public class JavadocTagCheck extends Check {
             final JavadocTag tag = aTags.get(i);
             if (tag.getTagName().equals(aTag)) {
                 tagCount++;
-                if (!aFormatPattern.matcher(tag.getArg1()).find()) {
+                if (!aFormatPattern.matcher(tag.getFirstArg()).find()) {
                     log(aLineNo, "type.tagFormat", "@" + aTag, aFormat);
                 }
             }

--- a/src/main/resources/opower_checks.xml
+++ b/src/main/resources/opower_checks.xml
@@ -110,6 +110,12 @@
             <property name="message" value="Old/Legacy import of Apache commons-lang v2 library. Use the commons-lang3 variant if possible, or wrap import in CHECKSTYLE_OFF exclusions if not possible."/>
             <property name="ignoreComments" value="true"/>
         </module>
+        <module name="RegexpSinglelineJava">
+            <property name="id" value="illegalImportShadedPackages"/>
+            <property name="format" value="^import .*\.shaded\..*;$"/>
+            <property name="message" value="Illegal import of shaded package. Use the non-shaded version instead."/>
+            <property name="ignoreComments" value="true"/>
+        </module>
 
 
         <!-- Checks for Size Violations.                    -->

--- a/src/test/java/com/opower/checkstyle/checks/javadoc/TestJavadocTagCheck.java
+++ b/src/test/java/com/opower/checkstyle/checks/javadoc/TestJavadocTagCheck.java
@@ -3,7 +3,7 @@ package com.opower.checkstyle.checks.javadoc;
 import java.util.regex.PatternSyntaxException;
 
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
-import com.puppycrawl.tools.checkstyle.api.JavadocTagInfo;
+import com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTagInfo;
 import org.junit.Test;
 
 import com.opower.checkstyle.checks.BaseCheckTestSupport;
@@ -61,24 +61,15 @@ public class TestJavadocTagCheck extends BaseCheckTestSupport {
     }
 
     @Test
-    public void testFileNotExist() throws Exception {
-        final DefaultConfiguration checkConfig = createCheckConfig(JavadocTagCheck.class);
-        final String[] expected = {
-                "0: File not found!",
-        };
-        verify(checkConfig, getSrcPath("NotExistingfile.java"), expected);
-    }
-
-    @Test
     public void testMissingJavadocComment() throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(JavadocTagCheck.class);
         checkConfig.addAttribute("tagName", SINCE_TAG_NAME);
         checkConfig.addAttribute("format", "\\S");
         final String[] expected = {
-                "3: Missing a Javadoc comment",
-                "6: Missing a Javadoc comment",
-                "9: Missing a Javadoc comment",
-                "12: Missing a Javadoc comment",
+                "3: error: Missing a Javadoc comment",
+                "6: error: Missing a Javadoc comment",
+                "9: error: Missing a Javadoc comment",
+                "12: error: Missing a Javadoc comment",
         };
         verify(checkConfig, getSrcPath("withoutjavadoc/WithoutJavadoc.java"), expected);
     }
@@ -89,7 +80,7 @@ public class TestJavadocTagCheck extends BaseCheckTestSupport {
         checkConfig.addAttribute("tagName", SINCE_TAG_NAME);
         checkConfig.addAttribute("format", "\\S");
         final String[] expected = {
-                "1: Missing a Javadoc comment"
+                "1: error: Missing a Javadoc comment"
         };
         verify(checkConfig, getSrcPath("withoutjavadoc/package-info.java"), expected);
     }
@@ -128,10 +119,10 @@ public class TestJavadocTagCheck extends BaseCheckTestSupport {
         checkConfig.addAttribute("tagName", SINCE_TAG_NAME);
         checkConfig.addAttribute("format", "\\S");
         final String[] expected = {
-                "11: Type Javadoc comment is missing an @since tag.",
-                "18: Type Javadoc comment is missing an @since tag.",
-                "25: Type Javadoc comment is missing an @since tag.",
-                "32: Type Javadoc comment is missing an @since tag."
+                "11: error: Type Javadoc comment is missing an @since tag.",
+                "18: error: Type Javadoc comment is missing an @since tag.",
+                "25: error: Type Javadoc comment is missing an @since tag.",
+                "32: error: Type Javadoc comment is missing an @since tag."
         };
         verify(checkConfig, getSrcPath("withoutsince/WithoutSince.java"), expected);
     }
@@ -142,10 +133,10 @@ public class TestJavadocTagCheck extends BaseCheckTestSupport {
         checkConfig.addAttribute("tagName", SINCE_TAG_NAME);
         checkConfig.addAttribute("format", "ABC");
         final String[] expected = {
-                "12: Type Javadoc tag @since must match pattern 'ABC'.",
-                "20: Type Javadoc tag @since must match pattern 'ABC'.",
-                "28: Type Javadoc tag @since must match pattern 'ABC'.",
-                "36: Type Javadoc tag @since must match pattern 'ABC'."
+                "12: error: Type Javadoc tag @since must match pattern 'ABC'.",
+                "20: error: Type Javadoc tag @since must match pattern 'ABC'.",
+                "28: error: Type Javadoc tag @since must match pattern 'ABC'.",
+                "36: error: Type Javadoc tag @since must match pattern 'ABC'."
         };
         verify(checkConfig, getSrcPath("withsince/WithSince.java"), expected);
     }
@@ -166,7 +157,7 @@ public class TestJavadocTagCheck extends BaseCheckTestSupport {
         checkConfig.addAttribute("tagName", SINCE_TAG_NAME);
         checkConfig.addAttribute("format", "\\S");
         final String[] expected = {
-                "4: Type Javadoc comment is missing an @since tag."
+                "4: error: Type Javadoc comment is missing an @since tag."
         };
         verify(checkConfig, getSrcPath("withoutsince/package-info.java"), expected);
     }
@@ -177,7 +168,7 @@ public class TestJavadocTagCheck extends BaseCheckTestSupport {
         checkConfig.addAttribute("tagName", SINCE_TAG_NAME);
         checkConfig.addAttribute("format", "ABC");
         final String[] expected = {
-                "5: Type Javadoc tag @since must match pattern 'ABC'."
+                "5: error: Type Javadoc tag @since must match pattern 'ABC'."
         };
         verify(checkConfig, getSrcPath("withsince/package-info.java"), expected);
     }


### PR DESCRIPTION
The shaded imports business relies on the convention that the package has ".shaded." as a part of the path (e.g., `autovalue.shaded.com.google.common.common`). It's not surefire, but it's the best I've got.

I removed one test from `TestJavadocTagCheck` because it was a) causing problems with the new versions of checkstyle b) was testing functionality that was not a part of the `JavadocTagCheck` to begin with.