### PR TITLE
Update opower-parent to 2.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.opower</groupId>
         <artifactId>opower-parent</artifactId>
-        <version>2.4.0</version>
+        <version>2.6.0</version>
     </parent>
 
     <developers>

--- a/release_notes.txt
+++ b/release_notes.txt
@@ -1,6 +1,7 @@
 1.1.0
  * Prohibit import of shaded packages (if the full package name includes ".shaded.")
  * Upgrade to Checkstyle 6.11
+ * Upgrade to opower-parent 2.6.0
 
 1.0.0
  * Initial commit for open sourcing opower-checks


### PR DESCRIPTION
opower-parent 2.5.1 contains an updated maven-checkstyle-plugin (from version 2.15 to 2.17)